### PR TITLE
feat: support AIA_LOG_STREAM

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "wlog"
-version = "0.1.1"
+version = "0.1.2"
 description = ""
 authors = ["wacul <dev@wacul.co.jp>"]
 

--- a/wlog/__init__.py
+++ b/wlog/__init__.py
@@ -6,7 +6,7 @@ getLogger = get_logger  # backward comapatibility of python stdlib
 
 # sample output is here
 # AIA_LOG_FORMART=text python <file.py>
-# AIA_LOG_LEVEL=debug AIA_LOG_FORMAT=text python <file.py>
+# AIA_LOG_LEVEL=debug AIA_LOG_FORMAT=text AIA_LOG_STREAM=stderr python <file.py>
 # python <file.py>
 
 __all__ = ["setup", "get_logger", "suppress_logging"]

--- a/wlog/_logger.py
+++ b/wlog/_logger.py
@@ -230,7 +230,12 @@ def suppress_logging():
 
 
 def setup(
-    level=None, context_class=None, processors=None, logger_factory=None, **kwargs
+    level=None,
+    stream=None,
+    context_class=None,
+    processors=None,
+    logger_factory=None,
+    **kwargs
 ):
     if level is None:
         level = os.environ.get("AIA_LOG_LEVEL")
@@ -239,7 +244,8 @@ def setup(
 
     if logger_factory is None:
         if os.environ.get("AIA_LOG_STREAM", "").lower() == "stderr":
-            logger_factory = structlog.PrintLoggerFactory(sys.stderr)
+            stream = sys.stderr
+        logger_factory = structlog.PrintLoggerFactory(stream)
 
     kwargs["logger_factory"] = logger_factory
     kwargs["context_class"] = context_class or make_ordered_context
@@ -247,7 +253,7 @@ def setup(
     structlog.configure(**kwargs)
 
     if level is not None:
-        logging.basicConfig(level=level)
+        logging.basicConfig(level=level, stream=stream)
         set_loglevel(level)
 
     # setup sys hooks

--- a/wlog/_logger.py
+++ b/wlog/_logger.py
@@ -229,11 +229,17 @@ def suppress_logging():
     structlog.configure(logger_factory=lambda *args, **kwargs: structlog.ReturnLogger())
 
 
-def setup(level=None, context_class=None, processors=None, **kwargs):
+def setup(
+    level=None, context_class=None, processors=None, logger_factory=None, **kwargs
+):
     if level is None:
         level = os.environ.get("AIA_LOG_LEVEL")
     if level is not None:
         level = level.upper()
+
+    if os.environ.get("AIA_LOG_STREAM", "").lower() == "stderr":
+        logger_factory = structlog.PrintLoggerFactory(sys.stderr)
+        kwargs["logger_factory"] = logger_factory
 
     kwargs["context_class"] = context_class or make_ordered_context
     kwargs["processors"] = processors or DEFAULT_PROCESSORS

--- a/wlog/_logger.py
+++ b/wlog/_logger.py
@@ -237,10 +237,11 @@ def setup(
     if level is not None:
         level = level.upper()
 
-    if os.environ.get("AIA_LOG_STREAM", "").lower() == "stderr":
-        logger_factory = structlog.PrintLoggerFactory(sys.stderr)
-        kwargs["logger_factory"] = logger_factory
+    if logger_factory is None:
+        if os.environ.get("AIA_LOG_STREAM", "").lower() == "stderr":
+            logger_factory = structlog.PrintLoggerFactory(sys.stderr)
 
+    kwargs["logger_factory"] = logger_factory
     kwargs["context_class"] = context_class or make_ordered_context
     kwargs["processors"] = processors or DEFAULT_PROCESSORS
     structlog.configure(**kwargs)


### PR DESCRIPTION
```console
# default output is stdout
$ poetry run python _examples/00hello.py  > /tmp/a

$ AIA_LOG_STREAM=stderr poetry run python _examples/00hello.py  > /tmp/a
{"time": "2021-11-04T11:49:02.520150+0900", "level": "info", "msg": "hello", "caller": "~/ghq/github.com/wacul/python-wlog/_examples/00hello.py:7", "source": "__main__", "xxx": "yyy"}
```